### PR TITLE
How about turning off the default build reports generation feature

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,6 +30,7 @@
         <cdi.version>1.0-SP4</cdi.version>
         <webbeans.version>1.1.5</webbeans.version>
         <dist.finalName>${project.artifactId}-${project.version}</dist.finalName>
+        <closeTestReports>true</closeTestReports>
     </properties>
 
     <licenses>
@@ -256,6 +257,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
+                <disableXmlReport>${closeTestReports}</disableXmlReport>
                 <version>2.12</version>
             </plugin>
             <plugin>


### PR DESCRIPTION
That report generation takes time, slowing down the overall build. Reports are definitely useful, but do you need them every time you run the build. We can conditionally disable generating test reports by setting `<disableXmlReport>true<disableXmlReport>`. If you need to generate reports, just add `-DcloseTestReports=false` to the end of mvn build command.